### PR TITLE
Fix get_column_type for reorganized system table in C* 3.0

### DIFF
--- a/cassandra_migrations.gemspec
+++ b/cassandra_migrations.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['s/**/*_s.rb']
 
   # s.add_dependency: Production dependencies
-  s.add_runtime_dependency 'cassandra-driver', '~> 3.0', '>= 2.1.1'
+  s.add_runtime_dependency 'cassandra-driver', '~> 3.0'
   s.add_runtime_dependency 'rake', '~> 10'
   s.add_runtime_dependency 'rails', '>= 3.2'
   s.add_runtime_dependency 'colorize', '~> 0.7.3'

--- a/lib/cassandra_migrations/cassandra/queries.rb
+++ b/lib/cassandra_migrations/cassandra/queries.rb
@@ -106,28 +106,9 @@ module CassandraMigrations
 
     private
 
-      SYMBOL_FOR_TYPE = {
-        'SetType' => :set,
-        'ListType' => :list,
-        'MapType' => :map,
-        'BooleanType' => :boolean,
-        'FloatType' => :float,
-        'Int32Type' => :int,
-        'DateType' => :timestamp,
-        'UTF8Type' => :string,
-        'BytesType' => :blob,
-        'UUIDType' => :uuid,
-        'DoubleType' => :double,
-        'InetAddressType' => :inet,
-        'AsciiType' => :ascii,
-        'LongType' => :bigint ,
-        'DecimalType' => :decimal,
-        'TimeUUIDType' => :timeuuid
-      }
-
       def get_column_type(table, column)
-        column_info = client.execute("SELECT VALIDATOR FROM system.schema_columns WHERE keyspace_name = '#{client.keyspace}' AND columnfamily_name = '#{table}' AND column_name = '#{column}'")
-        SYMBOL_FOR_TYPE[(column_info.first['validator'].split(/[\.(]/) & SYMBOL_FOR_TYPE.keys).first]
+        column_type = client.execute("SELECT type FROM system_schema.columns WHERE keyspace_name = '#{client.keyspace}' AND table_name = '#{table}' AND column_name = '#{column}'").first['type']
+        column_type.split("<").first.to_sym
       end
 
       def to_cql_value(column, value, table, options={})

--- a/spec/cassandra_migrations/cassandra/queries_spec.rb
+++ b/spec/cassandra_migrations/cassandra/queries_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 describe CassandraMigrations::Cassandra::Queries do
 
   def set_column_info(type)
-    @column_info = [{'validator' => "org.apache.cassandra.db.marshal.#{type}(org.apache.cassandra.db.marshal.UTF8Type"}]
+    @column_info = [{'type' => "#{type}"}]
   end
 
   before :each do
     @client = double("client", {keyspace: 'test_keyspace'})
     allow(TestQueryExecutor).to receive(:client).and_return(@client)
-    @cql_command_for_validator = "SELECT VALIDATOR FROM system.schema_columns WHERE keyspace_name = 'test_keyspace' AND columnfamily_name = 'people' AND column_name = 'friends'"
+    @cql_command_for_validator = "SELECT type FROM system_schema.columns WHERE keyspace_name = 'test_keyspace' AND table_name = 'people' AND column_name = 'friends'"
   end
 
   class TestQueryExecutor
@@ -68,7 +68,7 @@ describe CassandraMigrations::Cassandra::Queries do
     context 'when dealing with collections' do
 
       it 'should handle setting a set collection column value' do
-        set_column_info('SetType')
+        set_column_info('set<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(
@@ -79,7 +79,7 @@ describe CassandraMigrations::Cassandra::Queries do
       end
 
       it 'should handle setting a list collection column value' do
-        set_column_info('ListType')
+        set_column_info('list<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(
@@ -133,7 +133,7 @@ describe CassandraMigrations::Cassandra::Queries do
     context 'when dealing with collections' do
 
       it 'should handle setting a set collection column' do
-        set_column_info('SetType')
+        set_column_info('set<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(
@@ -144,7 +144,7 @@ describe CassandraMigrations::Cassandra::Queries do
       end
 
       it 'should handle adding elements to a set collection column' do
-        set_column_info('SetType')
+        set_column_info('set<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(
@@ -157,7 +157,7 @@ describe CassandraMigrations::Cassandra::Queries do
       end
 
       it 'should handle removing elements from a set collection column' do
-        set_column_info('SetType')
+        set_column_info('set<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(
@@ -170,7 +170,7 @@ describe CassandraMigrations::Cassandra::Queries do
       end
 
       it 'should handle setting a list collection column' do
-        set_column_info('ListType')
+        set_column_info('list<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(
@@ -181,7 +181,7 @@ describe CassandraMigrations::Cassandra::Queries do
       end
 
       it 'should handle adding elements to a list collection column' do
-        set_column_info('ListType')
+        set_column_info('list<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(
@@ -194,7 +194,7 @@ describe CassandraMigrations::Cassandra::Queries do
       end
 
       it 'should handle removing elements from a list collection column' do
-        set_column_info('ListType')
+        set_column_info('list<text>')
         expect(@client).to receive(:execute).with(@cql_command_for_validator).and_return(@column_info)
 
         allow(TestQueryExecutor).to receive(:execute).with(


### PR DESCRIPTION
C\* 3.0 no longer has a system table but instead has a system_schema
which stores column type info in a different manner

Fix `get_column_type` to properly parse info from this new table.
Remove SYMBOL_FOR_TYPE hash as its no longer needed.
